### PR TITLE
Errors when there is no comment and wrong comment.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,17 +41,19 @@ module.exports = stylelint.createPlugin(ruleName, (actual, options = {}, context
           if (isFixEnabled) {
             // Don't report, fix will be applied
             comment.remove()
-          } else {
-            stylelint.utils.report({
-              message: messages.rejected,
-              node: comment,
-              result,
-              ruleName,
-            })
           }
         }
       }
     })
+
+    if (!isLicenseHeaderPresent) {
+      stylelint.utils.report({
+        message: messages.rejected,
+        node: root,
+        result,
+        ruleName,
+      })
+    }
 
     if (!isLicenseHeaderPresent && isFixEnabled) {
       const newline = context.newline


### PR DESCRIPTION
Currently if you run stylelint with this plugin with no comments it does not report any errors, `--fix` will add the headers but problems are not reported.

This change moves the reporting out of the check that the comment is the same to ensure that the error is reported when there is no header and when the header is incorrect.